### PR TITLE
Allow parse option

### DIFF
--- a/backbone-live.js
+++ b/backbone-live.js
@@ -81,11 +81,7 @@
 				});
 
 				this.pusherChannel.bind("update_" + this.eventType, function(model) {
-					var modelIdAttribute = _this._idAttr;
-					var modelId = model[modelIdAttribute];
-					if (_this.get(modelId)) {
-						_this.get(modelId).set(model);
-					}
+					_this.add(model, {merge: true, parse: options.parse});
 				});
 
 				this.pusherChannel.bind("reset_" + this.eventType, function(models) {
@@ -210,8 +206,7 @@
 				}
 
 				this.pusherChannel.bind("update_" + this.eventType, function(model) {
-					var modelId = model[_this.idAttribute];
-					if (_this.id === modelId) {
+					if (_this.get("id") === model.id) {
 						_this.set(model);
 					}
 				});

--- a/backbone-live.js
+++ b/backbone-live.js
@@ -33,6 +33,7 @@
 			// default to polling if there's no arguments
 			options = options || {};
 			options.liveType = options.liveType || "poll";
+			options.parse = options.parse || false;
 
   			// if they've supplied a Pusher object or an existing pusherChannel, 
   			// set it up to use Pusher
@@ -72,7 +73,7 @@
 				}
 
 				this.pusherChannel.bind("add_" + this.eventType, function(model) {
-					_this.add(model);
+					_this.add(model, {parse: options.parse});
 				});
 
 				this.pusherChannel.bind("remove_" + this.eventType, function(model) {

--- a/backbone-live.js
+++ b/backbone-live.js
@@ -33,7 +33,7 @@
 			// default to polling if there's no arguments
 			options = options || {};
 			options.liveType = options.liveType || "poll";
-			options.parse = options.parse || false;
+			options.parse = options.parse || true;
 
   			// if they've supplied a Pusher object or an existing pusherChannel, 
   			// set it up to use Pusher

--- a/backbone-live.js
+++ b/backbone-live.js
@@ -81,8 +81,10 @@
 				});
 
 				this.pusherChannel.bind("update_" + this.eventType, function(model) {
-					if (_this.get(model.id)) {
-						_this.get(model.id).set(model);
+					var modelIdAttribute = _this._idAttr;
+					var modelId = model[modelIdAttribute];
+					if (_this.get(modelId)) {
+						_this.get(modelId).set(model);
 					}
 				});
 
@@ -208,7 +210,8 @@
 				}
 
 				this.pusherChannel.bind("update_" + this.eventType, function(model) {
-					if (_this.get("id") === model.id) {
+					var modelId = model[_this.idAttribute];
+					if (_this.id === modelId) {
 						_this.set(model);
 					}
 				});


### PR DESCRIPTION
Very simple change. I needed my new models from Pusher to be added to the collection with parse=true, e.g.
    myCollection.add(model, {parse: true});

So I changed 2 lines to check for the parse option, and use it when we call add(). This is tested and working in my project.

Open to feedback.
Cheers.
